### PR TITLE
cover-webpack.config.js needs style-loader and css-loader npm dependencies

### DIFF
--- a/cover-webpack.config.js
+++ b/cover-webpack.config.js
@@ -1,5 +1,9 @@
 module.exports = {
 	entry: "mocha!./test/cover-client-tests",
+	output: {
+		path: "assets",
+		publicPath: "/assets/"
+	},
 	module: {
 		loaders: [
 			{ test: /\.json$/, loader: "json" },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
 		"expose-loader": "0.5.x",
 		"worker-loader": "0.5.x",
 		"json5-loader": "0.5.x",
-		"json-loader": "0.5.x"
+		"json-loader": "0.5.x",
+		"style-loader": "0.6.x",
+		"css-loader": "0.6.x"
 	},
 	"scripts": {
 		"test": "node bin/enhanced-require mocha!./test/server-tests"


### PR DESCRIPTION
To make `cover-webpack.config.js` work on my machine, I had to

```
    npm install style-loader css-loader --save
```

and add 

```
    output: {path:"assets", publicPath:"/assets/"}
```

to `cover-webpac.config.js`.
